### PR TITLE
Fix newline stripping in numbered file output

### DIFF
--- a/agent_v79w_copy.py
+++ b/agent_v79w_copy.py
@@ -1738,7 +1738,10 @@ class FileSystemTools:
             if not sliced_lines and total_lines == 0:
                 content = "Файл пуст"
             else:
-                numbered = [f"{idx:>6}⟶{line.rstrip('\n')}" for idx, line in enumerate(sliced_lines, start=start + 1)]
+                numbered = []
+                for idx, line in enumerate(sliced_lines, start=start + 1):
+                    stripped_line = line.rstrip('\n')
+                    numbered.append(f"{idx:>6}⟶{stripped_line}")
                 content = "\n".join(numbered)
 
             return ToolResult(


### PR DESCRIPTION
## Summary
- avoid using an inline newline escape in the file numbering f-string to prevent SyntaxError on some interpreters
- build the numbered output incrementally while stripping trailing newlines safely

## Testing
- python -m py_compile agent_v79w_copy.py

------
https://chatgpt.com/codex/tasks/task_e_68cfad15aa888321b055a45436b6a958