### PR TITLE
Fix GigaChat reminder message order

### DIFF
--- a/agent_v79w_copy.py
+++ b/agent_v79w_copy.py
@@ -3507,10 +3507,21 @@ class SmartAgent:
                             "Модель попыталась завершить задачу без инструментов (попытка %s). Отправлено напоминание.",
                             lazy_response_attempts
                         )
-                        messages.append({
-                            "role": "system",
-                            "content": reminder_message
-                        })
+
+                        reminder_block = (
+                            f"\n\n[СИСТЕМНОЕ НАПОМИНАНИЕ #{lazy_response_attempts}] "
+                            f"{reminder_message}"
+                        )
+
+                        if messages and messages[0].get("role") == "system":
+                            messages[0]["content"] = (
+                                messages[0].get("content", "") + reminder_block
+                            )
+                        else:
+                            messages.insert(0, {
+                                "role": "system",
+                                "content": reminder_message
+                            })
 
                         note_text = (
                             f"Напоминание о необходимости вызвать инструменты (попытка {lazy_response_attempts})"


### PR DESCRIPTION
## Summary
- append lazy-response reminders to the initial system prompt instead of adding new system messages later in the conversation
- ensure the system prompt remains the first message when calling the GigaChat API to satisfy its validation rules

## Testing
- python -m compileall agent_v79w_copy.py

------
https://chatgpt.com/codex/tasks/task_e_68cfbec798c88321882839c65b30320a